### PR TITLE
fix Flutter example maybe crash when open app by deep link (#212)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+  }
+}

--- a/flutter/example/ios/Runner/AppDelegate.swift
+++ b/flutter/example/ios/Runner/AppDelegate.swift
@@ -17,6 +17,8 @@ import CoinbaseWalletSDK
       open url: URL, 
       options: [UIApplication.OpenURLOptionsKey : Any] = [:]
     ) -> Bool {
+        guard CoinbaseWalletSDK.isConfigured else { return false }
+        
         if (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
             return true
         }
@@ -29,6 +31,8 @@ import CoinbaseWalletSDK
       continue userActivity: NSUserActivity, 
       restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
     ) -> Bool {
+        guard CoinbaseWalletSDK.isConfigured else { return false }
+        
         if let url = userActivity.webpageURL,
            (try? CoinbaseWalletSDK.shared.handleResponse(url)) == true {
             return true


### PR DESCRIPTION
* fix wallet_switchEthereumChain

* fix Crash where open app by deep link.

* revert flutter/example/ios/Runner/AppDelegate.swift

* Changed: Type of chainId parameter on SwitchEthereumChain to string

* fix Flutter example maybe crash when open app by deep link.

* guard (CoinbaseWalletSDK.isConfigured) else { return false }

---------

### _Summary_

<!--
  What changed? Link to relevant issues.
-->

### _How did you test your changes?_

<!--
  Verify changes. Include relevant screenshots/videos
-->
